### PR TITLE
Add context markdowns for Claude and GitHub Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# GitHub Copilot Instructions – Yale
+
+## Project
+
+Yale is a **.NET 6.0 C# library** that compiles string expressions (e.g., `sqrt(a^2 + b^2)`, `age > 18 AND name() = "Alice"`) to CIL (Common Intermediate Language) for fast runtime evaluation. It is a modernization of the Flee library. LGPL-3.0 licensed.
+
+## Tech Stack
+
+- **Language:** C# on .NET 6.0
+- **Testing:** MSTest (`test/Yale.Tests/`)
+- **Benchmarking:** BenchmarkDotNet (`benchmark/Yale.Benchmarks/`)
+- **Formatter:** CSharpier (enforced via Husky pre-commit hook)
+- **NuGet package:** `Yale` by Espen Skaufel
+
+## Key Directories
+
+| Path | Purpose |
+|------|---------|
+| `src/Yale/Engine/` | Public API — `ComputeInstance` and `ComputeInstanceOptions` |
+| `src/Yale/Expression/Elements/` | AST nodes; each emits CIL via `ILGenerator` |
+| `src/Yale/Parser/` | Tokenizer and grammar for expression strings |
+| `src/Yale/Core/Interfaces/` | Core public interfaces |
+| `src/Yale/Resources/` | Localized error messages (`.resx`); Designer.cs files are auto-generated |
+| `test/Yale.Tests/` | Unit tests organized by subsystem |
+
+## Coding Conventions
+
+- **Interfaces** must be prefixed with `I` (e.g., `IExpressionElement`).
+- **Types and members** use PascalCase.
+- **Nullable reference types** are enabled — do not suppress with `!` unless strictly necessary.
+- `using` directives go **outside** the namespace.
+- Prefer **file-scoped namespaces** (`namespace Foo;`).
+- Use `var` when the type is clear from context.
+- Prefer expression-bodied members for single-expression properties and methods.
+- Use pattern matching and switch expressions over explicit type casts where natural.
+- Format code with **CSharpier** before committing (`dotnet csharpier .`).
+- Do not edit `*.Designer.cs` files — they are auto-generated from `.resx` resources.
+
+## Common Tasks
+
+```bash
+dotnet restore          # restore packages
+dotnet build            # build solution
+dotnet test             # run all tests
+dotnet csharpier .      # format code
+```
+
+## Patterns to Follow
+
+- New expression element types go in `src/Yale/Expression/Elements/` and inherit from the appropriate base class in `Elements/Base/`.
+- Add corresponding unit tests in `test/Yale.Tests/ExpressionTests/`.
+- Error messages belong in `src/Yale/Resources/CompileErrors.resx` or `GeneralErrors.resx`; reference them via the generated Designer class.
+- Benchmarks for new features go in `benchmark/Yale.Benchmarks/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Yale – Claude Code Context
+
+## Project Overview
+
+Yale is a .NET 6.0 expression parser and evaluator library. It compiles string expressions (e.g., `sqrt(a^2 + b^2)`, `name() = "Maria"`) to Common Intermediate Language (CIL) for fast runtime evaluation. It is a modernization of the [Flee](https://github.com/mparlak/Flee) library. Licensed under LGPL-3.0.
+
+## Repository Structure
+
+```
+src/Yale/
+  Expression/         # Expression compilation pipeline
+    Elements/         # Operator and literal AST nodes
+    Elements/Base/    # Base classes for expression elements
+    Elements/Literals/
+    Elements/LogicalBitwise/
+    Elements/MemberElements/
+  Core/Interfaces/    # Public-facing interfaces
+  Engine/             # Compilation entry points (ComputeInstance, options)
+    Interface/
+    Internal/
+  Parser/             # Tokenizer / grammar (RE/, Internal/)
+  Resources/          # Localized error message .resx files
+test/Yale.Tests/      # MSTest unit tests
+  Core/, Engine/, ExpressionTests/, Parser/, Theory/, Helper/
+benchmark/Yale.Benchmarks/  # BenchmarkDotNet suite (Parse/, Engine/)
+```
+
+## Build & Test Commands
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Build (debug)
+dotnet build
+
+# Build (release)
+dotnet build --configuration Release
+
+# Run all tests
+dotnet test
+
+# Run a specific test project
+dotnet test test/Yale.Tests/
+
+# Run benchmarks
+dotnet run --project benchmark/Yale.Benchmarks/ --configuration Release
+```
+
+Pre-commit hooks (Husky + CSharpier) run automatically on `git commit`. To skip in CI, set `CICD=0`.
+
+## Code Style
+
+- **Formatter:** CSharpier (`dotnet csharpier .`) — run before committing.
+- **Nullable:** enabled project-wide; avoid `!` (null-forgiving) unless unavoidable.
+- **Naming:** interfaces prefix `I`, all types and members PascalCase.
+- **Usings:** outside namespace declarations.
+- **Braces:** omit for single-line bodies only when already conventional in surrounding code.
+- **`var`:** use freely; type annotation is not required when the type is apparent.
+- See `.editorconfig` for the full ruleset.
+
+## Architecture Notes
+
+- `ComputeInstance` (in `Engine/`) is the public entry point for compiling and evaluating expressions.
+- `ComputeInstanceOptions` controls variable/function resolution.
+- Expression nodes in `Expression/Elements/` emit CIL via `ILGenerator`; each element implements `Emit(ILGenerator)`.
+- Error messages live in `Resources/CompileErrors.resx` and `Resources/GeneralErrors.resx` (auto-generated Designer.cs files — do not edit by hand).
+- The parser in `Parser/` converts raw strings to an element tree that the engine then emits.
+
+## CI/CD
+
+The GitHub Actions workflow (`.github/workflows/publish_nuget_preview.yml`) is manually triggered (`workflow_dispatch`). It restores, builds in Release, packs with a date-based version suffix, and publishes to NuGet.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root with project overview, directory structure, build/test commands, code style rules, and architecture notes for Claude Code.
- Adds `.github/copilot-instructions.md` with equivalent guidance for GitHub Copilot, including a quick-reference table of key directories, coding conventions, and common task commands.

## Test plan

- [x] Verify `CLAUDE.md` is picked up by Claude Code when opening the repo
- [ ] Verify `.github/copilot-instructions.md` is recognized by GitHub Copilot in VS Code / JetBrains
- [ ] Review content for accuracy against the current codebase

https://claude.ai/code/session_01XUsNJiYve1dVJ1ybFF9muD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUsNJiYve1dVJ1ybFF9muD)_