### PR TITLE
Fix case-insensitive detection of U and L suffixes on integer literals

### DIFF
--- a/src/Yale/Expression/Elements/Base/Literals/IntegralLiteralElement.cs
+++ b/src/Yale/Expression/Elements/Base/Literals/IntegralLiteralElement.cs
@@ -32,8 +32,8 @@ internal abstract class IntegralLiteralElement : LiteralElement
             }
         }
 
-        var hasUSuffix = image.EndsWith('u') & !image.EndsWith("lu", comparison);
-        var hasLSuffix = image.EndsWith('l') & !image.EndsWith("ul", comparison);
+        var hasUSuffix = image.EndsWith("u", comparison) & !image.EndsWith("lu", comparison);
+        var hasLSuffix = image.EndsWith("l", comparison) & !image.EndsWith("ul", comparison);
         var hasUlSuffix = image.EndsWith("ul", comparison) | image.EndsWith("lu", comparison);
         var hasSuffix = hasUSuffix | hasLSuffix | hasUlSuffix;
 


### PR DESCRIPTION
## Summary

- `image.EndsWith('u')` and `image.EndsWith('l')` use the `char` overload, which is case-sensitive. An uppercase suffix like `100U` or `100L` was not detected, so the raw image (suffix still attached) was passed to `UInt64.Parse`, causing a `FormatException`.
- Fixed by switching to the `string` overload with the already-defined `StringComparison.OrdinalIgnoreCase` comparison, matching how the two-character `ul`/`lu` suffixes were already handled.

## Test plan

- [x] Run `dotnet test --filter IntegerLiterals` — should pass after fix
- [x] Run full test suite `dotnet test` — no regressions

https://claude.ai/code/session_01Eyic7xdgz3L9JDapfYvWD5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eyic7xdgz3L9JDapfYvWD5)_