### PR TITLE
Upgrade project from .NET 6 to .NET 8

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.x'
+          dotnet-version: '8.x'
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/publish_nuget_preview.yml
+++ b/.github/workflows/publish_nuget_preview.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '8.x'
       
       - name: Restore
         run: dotnet restore

--- a/benchmark/Yale.Benchmarks/Yale.Benchmarks.csproj
+++ b/benchmark/Yale.Benchmarks/Yale.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<EnableNETAnalyzers>false</EnableNETAnalyzers>

--- a/src/Yale/Yale.csproj
+++ b/src/Yale/Yale.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<RootNamespace>Yale</RootNamespace>
 		<AssemblyName>Yale</AssemblyName>
 		<VersionPrefix>2.0.0</VersionPrefix>

--- a/test/Yale.InteractiveConsole/Yale.InteractiveConsole.csproj
+++ b/test/Yale.InteractiveConsole/Yale.InteractiveConsole.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<EnableNETAnalyzers>false</EnableNETAnalyzers>
 		<RootNamespace>Yale.InteractiveConsole</RootNamespace>
 	</PropertyGroup>

--- a/test/Yale.Tests/Yale.Tests.csproj
+++ b/test/Yale.Tests/Yale.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<EnableNETAnalyzers>false</EnableNETAnalyzers>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>


### PR DESCRIPTION
## Summary

- Update `TargetFramework` to `net8.0` in all four projects: main library (`Yale.csproj`), test project, interactive console, and benchmarks
- Update `publish_nuget_preview.yml` dotnet-version from `6.x` to `8.x` and bump `actions/checkout` and `actions/setup-dotnet` to `v4`
- Update `pr_tests.yml` dotnet-version from `10.x` to `8.x` to align with the target framework

## Test plan

- [ ] PR CI build passes (dotnet build + dotnet test on net8.0)
- [ ] Verify NuGet pack produces a net8.0 TFM in the publish workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDnYyRyDg4JT42wdgDCKo6)_