### PR TITLE
Add Yale.Benchmarks BenchmarkDotNet project

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -26,3 +26,9 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build
+
+      - name: Build Benchmarks
+        run: dotnet build benchmark/Yale.Benchmarks/ --configuration Release --no-restore
+
+      - name: Validate Benchmarks
+        run: dotnet run --project benchmark/Yale.Benchmarks/ --configuration Release --no-build -- --job dry --filter "*"

--- a/Yale.sln
+++ b/Yale.sln
@@ -11,6 +11,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yale", "src\Yale\Yale.cspro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yale.Tests", "src\Yale.Tests\Yale.Tests.csproj", "{70564EC6-4B59-49CF-B569-6817428CBFE1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{C1A4F6B2-D8E3-4F7A-B591-3A2E5D9C1048}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yale.Benchmarks", "benchmark\Yale.Benchmarks\Yale.Benchmarks.csproj", "{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{935D9128-356C-4196-9F99-7C73FCDBACB0}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -34,6 +38,10 @@ Global
 		{70564EC6-4B59-49CF-B569-6817428CBFE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70564EC6-4B59-49CF-B569-6817428CBFE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70564EC6-4B59-49CF-B569-6817428CBFE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -42,6 +50,7 @@ Global
 		{E813C04F-7C8F-4033-9502-AC3D80158117} = {B3847C6A-A387-45AE-B697-7020F93A7120}
 		{0C11762F-C331-4AD7-BF2C-53236648A92A} = {B3847C6A-A387-45AE-B697-7020F93A7120}
 		{70564EC6-4B59-49CF-B569-6817428CBFE1} = {B3847C6A-A387-45AE-B697-7020F93A7120}
+		{F2B5C8D1-9E4A-4B3C-A672-5D8E1F2C3047} = {C1A4F6B2-D8E3-4F7A-B591-3A2E5D9C1048}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5F82BEF-A6B7-420C-9E8B-178962E2831D}

--- a/benchmark/Yale.Benchmarks/Engine/EvaluateBenchmarks.cs
+++ b/benchmark/Yale.Benchmarks/Engine/EvaluateBenchmarks.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+using Yale.Engine;
+
+namespace Yale.Benchmarks.Engine;
+
+/// <summary>
+/// Measures the cost of evaluating already-compiled expressions via GetResult.
+/// Setup compiles all expressions once; each benchmark iteration only calls GetResult.
+/// </summary>
+[MemoryDiagnoser]
+public class EvaluateBenchmarks
+{
+    private ComputeInstance _intInstance = null!;
+    private ComputeInstance _arithmeticInstance = null!;
+    private ComputeInstance _boolInstance = null!;
+    private ComputeInstance _chainedInstance = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _intInstance = new ComputeInstance();
+        _intInstance.AddExpression<int>("result", "42");
+
+        _arithmeticInstance = new ComputeInstance();
+        _arithmeticInstance.Variables.Add("a", 3.0);
+        _arithmeticInstance.Variables.Add("b", 4.0);
+        _arithmeticInstance.AddExpression<double>("result", "a * 2.0 + b / 1.5");
+
+        _boolInstance = new ComputeInstance();
+        _boolInstance.Variables.Add("a", 3.0);
+        _boolInstance.Variables.Add("b", 4.0);
+        _boolInstance.AddExpression<bool>("result", "a > 1.0 AND b < 10.0");
+
+        _chainedInstance = new ComputeInstance();
+        _chainedInstance.Variables.Add("x", 5);
+        _chainedInstance.AddExpression<int>("doubled", "x * 2");
+        _chainedInstance.AddExpression<int>("result", "doubled + 1");
+    }
+
+    [Benchmark]
+    public object IntegerLiteral() => _intInstance.GetResult("result");
+
+    [Benchmark]
+    public object ArithmeticExpression() => _arithmeticInstance.GetResult("result");
+
+    [Benchmark]
+    public object BooleanExpression() => _boolInstance.GetResult("result");
+
+    [Benchmark]
+    public object ChainedExpressions() => _chainedInstance.GetResult("result");
+}

--- a/benchmark/Yale.Benchmarks/Parse/ParseBenchmarks.cs
+++ b/benchmark/Yale.Benchmarks/Parse/ParseBenchmarks.cs
@@ -1,0 +1,48 @@
+using BenchmarkDotNet.Attributes;
+using Yale.Engine;
+
+namespace Yale.Benchmarks.Parse;
+
+/// <summary>
+/// Measures the cost of parsing and compiling expression strings into evaluable delegates.
+/// Each iteration creates a fresh ComputeInstance so prior state does not carry over.
+/// </summary>
+[MemoryDiagnoser]
+public class ParseBenchmarks
+{
+    [Benchmark]
+    public ComputeInstance IntegerLiteral()
+    {
+        var instance = new ComputeInstance();
+        instance.AddExpression<int>("expr", "42");
+        return instance;
+    }
+
+    [Benchmark]
+    public ComputeInstance ArithmeticExpression()
+    {
+        var instance = new ComputeInstance();
+        instance.Variables.Add("a", 3.0);
+        instance.Variables.Add("b", 4.0);
+        instance.AddExpression<double>("expr", "a * 2.0 + b / 1.5");
+        return instance;
+    }
+
+    [Benchmark]
+    public ComputeInstance BooleanExpression()
+    {
+        var instance = new ComputeInstance();
+        instance.Variables.Add("a", 3.0);
+        instance.Variables.Add("b", 4.0);
+        instance.AddExpression<bool>("expr", "a > 1.0 AND b < 10.0");
+        return instance;
+    }
+
+    [Benchmark]
+    public ComputeInstance StringLiteral()
+    {
+        var instance = new ComputeInstance();
+        instance.AddExpression<string>("expr", "\"hello world\"");
+        return instance;
+    }
+}

--- a/benchmark/Yale.Benchmarks/Program.cs
+++ b/benchmark/Yale.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmark/Yale.Benchmarks/Yale.Benchmarks.csproj
+++ b/benchmark/Yale.Benchmarks/Yale.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Yale\Yale.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds `benchmark/Yale.Benchmarks/` project targeting net8.0 with BenchmarkDotNet 0.14.0
- `Parse/ParseBenchmarks.cs` — measures parse+compile cost for integer literal, arithmetic, boolean, and string expressions (each creates a fresh `ComputeInstance`)
- `Engine/EvaluateBenchmarks.cs` — measures `GetResult` evaluation cost for pre-compiled expressions, including a chained-expression case
- Registers the project in `Yale.sln` under a new `benchmark` solution folder

## Test plan

- [x] `dotnet build benchmark/Yale.Benchmarks/ --configuration Release` compiles without errors
- [x] `dotnet run --project benchmark/Yale.Benchmarks/ --configuration Release` launches the BenchmarkDotNet switcher
- [x] Running all benchmarks produces output for all 4 Parse and 4 Engine benchmarks

https://claude.ai/code/session_01X3syCsYPkDMNKZ3baFVypd

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3syCsYPkDMNKZ3baFVypd)_