### PR TITLE
Cache reflection calls in ComputeInstance.EmitLoad

### DIFF
--- a/src/Yale/Engine/ComputeInstance.cs
+++ b/src/Yale/Engine/ComputeInstance.cs
@@ -1,5 +1,7 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Yale.Core;
 using Yale.Engine.Interface;
 using Yale.Engine.Internal;
@@ -10,6 +12,23 @@ namespace Yale.Engine;
 
 public class ComputeInstance
 {
+    private static readonly MethodInfo ComputeInstanceGetterMethod =
+        typeof(ExpressionContext)
+            .GetProperty(nameof(ExpressionContext.ComputeInstance))!
+            .GetGetMethod()!;
+
+    private static readonly MethodInfo GetResultOpenMethod = typeof(ComputeInstance)
+        .FindMembers(
+            MemberTypes.Method,
+            BindingFlags.Instance | BindingFlags.Public,
+            Type.FilterName,
+            "GetResult"
+        )
+        .Cast<MethodInfo>()
+        .First(m => m.IsGenericMethod);
+
+    private static readonly ConcurrentDictionary<Type, MethodInfo> GetResultClosedMethods = new();
+
     private readonly ComputeInstanceOptions options;
     internal ExpressionBuilder Builder { get; }
 
@@ -296,22 +315,13 @@ public class ComputeInstance
     /// <param name="ilGenerator"></param>
     internal void EmitLoad(string expressionKey, YaleIlGenerator ilGenerator)
     {
-        var propertyInfo = typeof(ExpressionContext).GetProperty(
-            nameof(ExpressionContext.ComputeInstance)
-        );
+        ilGenerator.Emit(OpCodes.Callvirt, ComputeInstanceGetterMethod);
 
-        ilGenerator.Emit(OpCodes.Callvirt, propertyInfo.GetGetMethod());
-
-        //Find and load expression result
-        var members = typeof(ComputeInstance).FindMembers(
-            MemberTypes.Method,
-            BindingFlags.Instance | BindingFlags.Public,
-            Type.FilterName,
-            "GetResult"
-        );
-        var methodInfo = members.Cast<MethodInfo>().First(method => method.IsGenericMethod);
         var resultType = ResultType(expressionKey);
-        methodInfo = methodInfo.MakeGenericMethod(resultType);
+        var methodInfo = GetResultClosedMethods.GetOrAdd(
+            resultType,
+            static t => GetResultOpenMethod.MakeGenericMethod(t)
+        );
 
         ilGenerator.Emit(OpCodes.Ldstr, expressionKey);
         ilGenerator.Emit(OpCodes.Call, methodInfo);


### PR DESCRIPTION
## Summary

- `GetProperty` and `FindMembers`+`Cast`+`First` are now `static readonly` fields, computed once at class load time instead of on every cross-expression IL emission
- `MakeGenericMethod` results are cached in a `ConcurrentDictionary<Type, MethodInfo>`, so each distinct result type pays the reflection cost only once per process lifetime

## Test plan

- [ ] Run existing test suite (`dotnet test`) — no behavioral changes expected
- [ ] Manually verify expressions that reference other expressions still evaluate correctly

https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE)_