### PR TITLE
Cache reflection calls in VariableCollection.GetVariableLoadMethod

### DIFF
--- a/src/Yale/Core/VariableCollection.cs
+++ b/src/Yale/Core/VariableCollection.cs
@@ -1,5 +1,7 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Yale.Core.Interfaces;
 
 namespace Yale.Core;
@@ -8,6 +10,15 @@ public sealed class VariableCollection
     : INotifyPropertyChanged,
         IEnumerable<KeyValuePair<string, object>>
 {
+    private static readonly MethodInfo GetVariableValueInternalOpenMethod =
+        typeof(VariableCollection).GetMethod(
+            nameof(GetVariableValueInternal),
+            BindingFlags.Public | BindingFlags.Instance
+        )!;
+
+    private static readonly ConcurrentDictionary<Type, MethodInfo> GetVariableValueClosedMethods =
+        new();
+
     private readonly Dictionary<string, IVariable> values = new();
 
     public void Clear() => values.Clear();
@@ -90,15 +101,11 @@ public sealed class VariableCollection
     /// </summary>
     /// <param name="variableType">Return value</param>
     /// <returns></returns>
-    internal static MethodInfo GetVariableLoadMethod(Type variableType)
-    {
-        var methodInfo = typeof(VariableCollection).GetMethod(
-            nameof(GetVariableValueInternal),
-            BindingFlags.Public | BindingFlags.Instance
+    internal static MethodInfo GetVariableLoadMethod(Type variableType) =>
+        GetVariableValueClosedMethods.GetOrAdd(
+            variableType,
+            static t => GetVariableValueInternalOpenMethod.MakeGenericMethod(t)
         );
-
-        return methodInfo!.MakeGenericMethod(variableType);
-    }
 
     public T GetVariableValueInternal<T>(string name) => (T)values[name].ValueAsObject;
 

--- a/src/Yale/Core/VariableCollection.cs
+++ b/src/Yale/Core/VariableCollection.cs
@@ -14,7 +14,11 @@ public sealed class VariableCollection
         typeof(VariableCollection).GetMethod(
             nameof(GetVariableValueInternal),
             BindingFlags.Public | BindingFlags.Instance
-        )!;
+        )
+        ?? throw new MissingMethodException(
+            typeof(VariableCollection).FullName,
+            nameof(GetVariableValueInternal)
+        );
 
     private static readonly ConcurrentDictionary<Type, MethodInfo> GetVariableValueClosedMethods =
         new();


### PR DESCRIPTION
## Summary

- The open `MethodInfo` for `GetVariableValueInternal` is now a `static readonly` field, resolved once at class load time instead of on every variable reference during compilation
- Closed generic `MethodInfo` results (per variable type) are cached in a `ConcurrentDictionary<Type, MethodInfo>`, so `MakeGenericMethod` is called at most once per distinct variable type per process lifetime

## Test plan

- [ ] Run existing test suite (`dotnet test`) — no behavioral changes expected
- [ ] Verify expressions with variables of various types (int, double, string, etc.) still evaluate correctly

https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE)_