### PR TITLE
Cache OwnerType at construction in ExpressionContext

### DIFF
--- a/src/Yale/Expression/ExpressionContext.cs
+++ b/src/Yale/Expression/ExpressionContext.cs
@@ -17,6 +17,7 @@ internal sealed class ExpressionContext
         BuilderOptions = builderOptions;
         ExpressionName = expressionName;
         Owner = owner;
+        OwnerType = owner?.GetType();
         Imports = imports;
         Variables = variables;
         ComputeInstance = computeInstance;
@@ -24,7 +25,7 @@ internal sealed class ExpressionContext
 
     public object Owner { get; }
 
-    public Type? OwnerType => Owner?.GetType();
+    public Type? OwnerType { get; }
 
     internal ExpressionBuilderOptions BuilderOptions { get; } = new ExpressionBuilderOptions();
 


### PR DESCRIPTION
## Summary

`OwnerType` was a computed property (`=> Owner?.GetType()`) called on every access during both the `Resolve` and `Emit` passes of member elements (`IdentifierElement`, `FunctionCallElement`, `MemberElement`). Since `Owner` is immutable after construction, this changes it to a read-only auto-property computed once in the constructor.

## Test plan

- [ ] Run existing test suite (`dotnet test`) — no behavioral changes expected
- [ ] Verify expressions using owner members still resolve and evaluate correctly

https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE)_