### PR TITLE
Replace List+ToArray in GetDependents with ArrayPool-backed ref struct

### DIFF
--- a/src/Yale/Engine/ComputeInstance.cs
+++ b/src/Yale/Engine/ComputeInstance.cs
@@ -102,7 +102,8 @@ public class ComputeInstance
 
         node.Dirty = true;
 
-        foreach (var dependent in dependencies.GetDependents(key))
+        using var dependents = dependencies.GetDependents(key);
+        foreach (var dependent in dependents)
         {
             TagNodeAndDependentsAsDirty(dependent);
         }
@@ -110,7 +111,8 @@ public class ComputeInstance
 
     private void RecalculateValues(object? sender, PropertyChangedEventArgs e)
     {
-        foreach (var dependentKey in dependencies.GetDependents(e.PropertyName!))
+        using var dependents = dependencies.GetDependents(e.PropertyName!);
+        foreach (var dependentKey in dependents)
         {
             RecalculateNodeAndDependents(dependentKey);
         }
@@ -126,7 +128,8 @@ public class ComputeInstance
         if (result.Equals(node.ResultAsObject))
             return;
 
-        foreach (var dependent in dependencies.GetDependents(key))
+        using var dependents = dependencies.GetDependents(key);
+        foreach (var dependent in dependents)
         {
             RecalculateNodeAndDependents(dependent);
         }
@@ -164,7 +167,8 @@ public class ComputeInstance
 
         AddExpression<T>(key, expression);
 
-        foreach (var dependent in dependencies.GetDependents(key))
+        using var dependents = dependencies.GetDependents(key);
+        foreach (var dependent in dependents)
         {
             if (options.Recalculate == ComputeInstanceOptions.RecalculateMode.Auto)
             {

--- a/src/Yale/Engine/Internal/DependencyManager.cs
+++ b/src/Yale/Engine/Internal/DependencyManager.cs
@@ -46,10 +46,10 @@ internal sealed class DependencyManager
 
     public DependentsResult GetDependents(string key)
     {
-        var result = new DependentsResult(initialCapacity: 8);
-        if (!Nodes.TryGetValue(key, out var node))
-            return result;
+        if (!Nodes.TryGetValue(key, out var node) || node.Dependents.Length == 0)
+            return default;
 
+        var result = new DependentsResult(initialCapacity: 8);
         foreach (var pair in node.Dependents)
             GetDependentsRecursive(pair, ref result);
 
@@ -99,7 +99,7 @@ internal sealed class DependencyManager
 /// </summary>
 internal ref struct DependentsResult
 {
-    private string[] _buffer;
+    private string[]? _buffer;
     private int _count;
 
     internal DependentsResult(int initialCapacity)
@@ -110,10 +110,15 @@ internal ref struct DependentsResult
 
     internal void Add(string item)
     {
-        if (_count == _buffer.Length)
+        if (_buffer is null)
+        {
+            _buffer = ArrayPool<string>.Shared.Rent(8);
+        }
+        else if (_count == _buffer.Length)
         {
             var grown = ArrayPool<string>.Shared.Rent(_buffer.Length * 2);
             _buffer.AsSpan(0, _count).CopyTo(grown);
+            _buffer.AsSpan(0, _count).Clear();
             ArrayPool<string>.Shared.Return(_buffer, clearArray: false);
             _buffer = grown;
         }
@@ -131,8 +136,9 @@ internal ref struct DependentsResult
     {
         if (_buffer is not null)
         {
-            ArrayPool<string>.Shared.Return(_buffer, clearArray: true);
-            _buffer = null!;
+            _buffer.AsSpan(0, _count).Clear();
+            ArrayPool<string>.Shared.Return(_buffer, clearArray: false);
+            _buffer = null;
         }
     }
 }

--- a/src/Yale/Engine/Internal/DependencyManager.cs
+++ b/src/Yale/Engine/Internal/DependencyManager.cs
@@ -1,4 +1,6 @@
-﻿namespace Yale.Engine.Internal;
+using System.Buffers;
+
+namespace Yale.Engine.Internal;
 
 /// <summary>
 /// Keeps track of expression dependencies
@@ -37,32 +39,28 @@ internal sealed class DependencyManager
 
     public string[] GetDirectDependents(string key)
     {
-        if (Nodes.ContainsKey(key) is false)
+        if (!Nodes.TryGetValue(key, out var node))
             return Array.Empty<string>();
-        return Nodes[key].Dependents;
+        return node.Dependents;
     }
 
-    public string[] GetDependents(string key)
+    public DependentsResult GetDependents(string key)
     {
-        if (Nodes.ContainsKey(key) is false)
-            return Array.Empty<string>();
+        var result = new DependentsResult(initialCapacity: 8);
+        if (!Nodes.TryGetValue(key, out var node))
+            return result;
 
-        List<string> dependents = new();
-        foreach (var pair in Nodes[key].Dependents)
-        {
-            GetDependentsRecursive(pair, dependents);
-        }
+        foreach (var pair in node.Dependents)
+            GetDependentsRecursive(pair, ref result);
 
-        return dependents.ToArray();
+        return result;
     }
 
-    private void GetDependentsRecursive(string nodeKey, ICollection<string> dependents)
+    private void GetDependentsRecursive(string nodeKey, ref DependentsResult dependents)
     {
         dependents.Add(nodeKey);
         foreach (var pair in Nodes[nodeKey].Dependents)
-        {
-            GetDependentsRecursive(pair, dependents);
-        }
+            GetDependentsRecursive(pair, ref dependents);
     }
 
     public string[] GetDirectPrecedents(string nodeKey) => Nodes[nodeKey].Precedents;
@@ -93,4 +91,46 @@ internal sealed class DependencyManager
     }
 
     public int DependencyNodes => Nodes.Count;
+}
+
+/// <summary>
+/// ArrayPool-backed buffer for iterating dependents without heap allocation per call.
+/// Must be disposed after use (use with `using var`).
+/// </summary>
+internal ref struct DependentsResult
+{
+    private string[] _buffer;
+    private int _count;
+
+    internal DependentsResult(int initialCapacity)
+    {
+        _buffer = ArrayPool<string>.Shared.Rent(initialCapacity > 0 ? initialCapacity : 1);
+        _count = 0;
+    }
+
+    internal void Add(string item)
+    {
+        if (_count == _buffer.Length)
+        {
+            var grown = ArrayPool<string>.Shared.Rent(_buffer.Length * 2);
+            _buffer.AsSpan(0, _count).CopyTo(grown);
+            ArrayPool<string>.Shared.Return(_buffer, clearArray: false);
+            _buffer = grown;
+        }
+        _buffer[_count++] = item;
+    }
+
+    public ReadOnlySpan<string>.Enumerator GetEnumerator() =>
+        _buffer is null
+            ? ReadOnlySpan<string>.Empty.GetEnumerator()
+            : _buffer.AsSpan(0, _count).GetEnumerator();
+
+    public void Dispose()
+    {
+        if (_buffer is not null)
+        {
+            ArrayPool<string>.Shared.Return(_buffer, clearArray: true);
+            _buffer = null!;
+        }
+    }
 }

--- a/src/Yale/Engine/Internal/DependencyManager.cs
+++ b/src/Yale/Engine/Internal/DependencyManager.cs
@@ -120,10 +120,12 @@ internal ref struct DependentsResult
         _buffer[_count++] = item;
     }
 
-    public ReadOnlySpan<string>.Enumerator GetEnumerator() =>
-        _buffer is null
-            ? ReadOnlySpan<string>.Empty.GetEnumerator()
-            : _buffer.AsSpan(0, _count).GetEnumerator();
+    public ReadOnlySpan<string>.Enumerator GetEnumerator()
+    {
+        ReadOnlySpan<string> span =
+            _buffer is null ? ReadOnlySpan<string>.Empty : new ReadOnlySpan<string>(_buffer, 0, _count);
+        return span.GetEnumerator();
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary

- `GetDependents` previously allocated a `new List<string>()` and called `.ToArray()` on every invocation — triggered on every variable change and expression recalculation
- A new `DependentsResult` ref struct owns a `string[]` rented from `ArrayPool<string>.Shared`; callers use `using var` + foreach and the array is returned to the pool when the scope exits
- `GetDependentsRecursive` takes `ref DependentsResult` so array growth (if the dependency fan-out exceeds the initial capacity of 8) is visible across recursive stack frames
- Also fixed a `ContainsKey` + indexer double lookup in both `GetDirectDependents` and `GetDependents` to use `TryGetValue`

## Test plan

- [ ] Run existing test suite (`dotnet test`) — no behavioral changes expected
- [ ] Verify expressions with chained dependencies recalculate correctly when variables change

https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hok5Dv1cCcyUq957qMEXBE)_