### PR TITLE
chore: update test framework packages to latest versions

### DIFF
--- a/src/Yale.Tests/Core/Import.cs
+++ b/src/Yale.Tests/Core/Import.cs
@@ -67,7 +67,7 @@ public class Import
     {
         _instance.Imports.AddMethod("Sqrt", typeof(Math), "Test");
 
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => _instance.AddExpression("key", "Test.Pow(16)")
         );
     }

--- a/src/Yale.Tests/Core/ValueCollection.cs
+++ b/src/Yale.Tests/Core/ValueCollection.cs
@@ -23,7 +23,7 @@ public class ValueCollection
     [TestMethod]
     public void SetValue_WithoutKey_ThrowsException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.Throws<ArgumentNullException>(() =>
         {
             Variables.Add(null, 2);
         });
@@ -32,12 +32,12 @@ public class ValueCollection
     [TestMethod]
     public void GetValue_WithoutKey_ThrowsException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.Throws<ArgumentNullException>(() =>
         {
             Variables.Get(null);
         });
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.Throws<ArgumentNullException>(() =>
         {
             Variables.Get<object>(null);
         });

--- a/src/Yale.Tests/Engine/ComputeInstanceTests.cs
+++ b/src/Yale.Tests/Engine/ComputeInstanceTests.cs
@@ -63,15 +63,15 @@ public class ComputeInstanceTests
     [TestMethod]
     public void AddExpression_ThatAreInvalid_ThrowsException()
     {
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => instance.AddExpression("a", "true > false")
         );
 
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => instance.AddExpression("a", "Hello there < 1")
         );
 
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => instance.AddExpression("a", "1 == true")
         );
     }
@@ -97,11 +97,11 @@ public class ComputeInstanceTests
 
     [TestMethod]
     public void Generic_GetResult_DoesNotExist() =>
-        Assert.ThrowsException<KeyNotFoundException>(() => instance.GetResult<int>("a"));
+        Assert.Throws<KeyNotFoundException>(() => instance.GetResult<int>("a"));
 
     [TestMethod]
     public void GetResult_DoesNotExist() =>
-        Assert.ThrowsException<KeyNotFoundException>(() => instance.GetResult("a"));
+        Assert.Throws<KeyNotFoundException>(() => instance.GetResult("a"));
 
     [TestMethod]
     public void GetExpression_ContainsExpression()
@@ -123,8 +123,8 @@ public class ComputeInstanceTests
     [TestMethod]
     public void GetExpression_ExpressionDoesNotExists_ThrowsException()
     {
-        Assert.ThrowsException<KeyNotFoundException>(() => instance.GetExpression("a"));
-        Assert.ThrowsException<KeyNotFoundException>(() => instance.GetExpression<bool>("a"));
+        Assert.Throws<KeyNotFoundException>(() => instance.GetExpression("a"));
+        Assert.Throws<KeyNotFoundException>(() => instance.GetExpression<bool>("a"));
     }
 
     [TestMethod]

--- a/src/Yale.Tests/ExpressionTests/Double.cs
+++ b/src/Yale.Tests/ExpressionTests/Double.cs
@@ -10,7 +10,6 @@ public class Double
     private readonly ComputeInstance _instance = new();
 
     [TestMethod]
-    [DataTestMethod]
     [DataRow("1.0", "+", "1.0", 2.0)]
     [DataRow("1.0", "-", "1.0", 0.0)]
     [DataRow("2.0", "*", "2.0", 4.0)]

--- a/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
+++ b/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
@@ -16,7 +16,7 @@ public class ExpressionBuilderOptionsTests
         _instance.AddExpression("a", int.MaxValue.ToString());
 
         //OverflowCheck
-        Assert.ThrowsException<OverflowException>(() => _instance.AddExpression("b", "a + 1"));
+        Assert.Throws<OverflowException>(() => _instance.AddExpression("b", "a + 1"));
         _instance.AddExpression("b", "a - 1");
 
         //IntegerAsDouble (Default == false)
@@ -25,16 +25,16 @@ public class ExpressionBuilderOptionsTests
         #region CaseSensitive
 
         //Variables
-        Assert.ThrowsException<ExpressionCompileException>(() => _instance.AddExpression("c", "A"));
+        Assert.Throws<ExpressionCompileException>(() => _instance.AddExpression("c", "A"));
         _instance.AddExpression("c", "a");
 
         //Expression
-        Assert.ThrowsException<ExpressionCompileException>(() => _instance.AddExpression("d", "C"));
+        Assert.Throws<ExpressionCompileException>(() => _instance.AddExpression("d", "C"));
         _instance.AddExpression("d", "c");
 
         //Members
         _instance.Variables.Add("rand", new Random());
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => _instance.AddExpression("e", "rand.nextDouble() + 100")
         );
         _instance.AddExpression("e", "rand.NextDouble() + 100");

--- a/src/Yale.Tests/ExpressionTests/Identifier.cs
+++ b/src/Yale.Tests/ExpressionTests/Identifier.cs
@@ -170,7 +170,7 @@ public class Identifier
         _instance.AddExpression("a", "x * 2");
         _instance.Variables.Add("y", 1);
 
-        Assert.ThrowsException<ExpressionCompileException>(() =>
+        Assert.Throws<ExpressionCompileException>(() =>
         {
             _instance.AddExpression("b", "a + y + b");
         });

--- a/src/Yale.Tests/ExpressionTests/Integer.cs
+++ b/src/Yale.Tests/ExpressionTests/Integer.cs
@@ -24,7 +24,6 @@ public class Integer
     }
 
     [TestMethod]
-    [DataTestMethod]
     [DataRow("1", "+", "1", 2)]
     [DataRow("1", "-", "1", 0)]
     [DataRow("2", "*", "2", 4)]

--- a/src/Yale.Tests/ExpressionTests/Integer.cs
+++ b/src/Yale.Tests/ExpressionTests/Integer.cs
@@ -66,10 +66,10 @@ public class Integer
     //[TestMethod]
     //public void IntegerPowerIntegerOverflow_Exception()
     //{
-    //    Assert.ThrowsException<OverflowException>(() => _instance.AddExpression("a", $"{int.MaxValue}2^2"));
-    //    Assert.ThrowsException<OverflowException>(() => _instance.AddExpression<int>("a", "2147483600^2"));
+    //    Assert.Throws<OverflowException>(() => _instance.AddExpression("a", $"{int.MaxValue}2^2"));
+    //    Assert.Throws<OverflowException>(() => _instance.AddExpression<int>("a", "2147483600^2"));
     //    //Int64
-    //    Assert.ThrowsException<OverflowException>(() => _instance.AddExpression("a", "21474836001^234123"));
+    //    Assert.Throws<OverflowException>(() => _instance.AddExpression("a", "21474836001^234123"));
     //}
 
     [TestMethod]
@@ -89,10 +89,10 @@ public class Integer
     [TestMethod]
     public void IntegerAdditionIntegerOverFlow_Exception()
     {
-        Assert.ThrowsException<OverflowException>(
+        Assert.Throws<OverflowException>(
             () => _instance.AddExpression("a", $"{long.MaxValue} + 1")
         );
-        Assert.ThrowsException<OverflowException>(
+        Assert.Throws<OverflowException>(
             () => _instance.AddExpression<long>("b", $"{long.MaxValue} + 1")
         );
     }
@@ -114,10 +114,10 @@ public class Integer
     [TestMethod]
     public void IntegerSubtractionIntegerOverFlow_Exception()
     {
-        Assert.ThrowsException<OverflowException>(
+        Assert.Throws<OverflowException>(
             () => _instance.AddExpression("a", $"{long.MinValue} - 1")
         );
-        Assert.ThrowsException<OverflowException>(
+        Assert.Throws<OverflowException>(
             () => _instance.AddExpression<long>("b", $"{long.MinValue} - 1")
         );
     }

--- a/src/Yale.Tests/Parser/Core.cs
+++ b/src/Yale.Tests/Parser/Core.cs
@@ -12,7 +12,7 @@ public class Core
     [TestMethod]
     public void Parse_InvalidToken_ThrowsException()
     {
-        Assert.ThrowsException<ExpressionCompileException>(
+        Assert.Throws<ExpressionCompileException>(
             () => instance.AddExpression<int>("a", "b")
         );
     }

--- a/src/Yale.Tests/Yale.Tests.csproj
+++ b/src/Yale.Tests/Yale.Tests.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
 	</ItemGroup>

--- a/src/Yale.Tests/Yale.Tests.csproj
+++ b/src/Yale.Tests/Yale.Tests.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- `Microsoft.NET.Test.Sdk`: 18.4.0 → 18.5.0
- `MSTest.TestAdapter`: 3.8.3 → 4.2.1
- `MSTest.TestFramework`: 3.8.3 → 4.2.1

## Test plan

- [ ] `dotnet restore` picks up the new package versions
- [ ] `dotnet test` passes with no regressions

https://claude.ai/code/session_012HrGbQh8jLJcWXEXuPmDNw

---
_Generated by [Claude Code](https://claude.ai/code/session_012HrGbQh8jLJcWXEXuPmDNw)_