### PR TITLE
test: add multi-argument function call tests

### DIFF
--- a/src/Yale.Tests/ExpressionTests/FunctionCall.cs
+++ b/src/Yale.Tests/ExpressionTests/FunctionCall.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yale.Engine;
+
+namespace Yale.Tests.ExpressionTests;
+
+[TestClass]
+public class FunctionCall
+{
+    private readonly ComputeInstance _instance = new();
+
+    [TestMethod]
+    public void TwoArgInstanceMethod_LiteralArgs_ReturnsExpected()
+    {
+        // Random.Next(minValue, maxValue) returns minValue when the range is a single value
+        _instance.Variables.Add("rand", new Random());
+        _instance.AddExpression<int>("e", "rand.Next(5, 6)");
+        Assert.AreEqual(5, _instance.GetResult<int>("e"));
+    }
+
+    [TestMethod]
+    public void TwoArgInstanceMethod_VariableArgs_ReturnsExpected()
+    {
+        _instance.Variables.Add("rand", new Random());
+        _instance.Variables.Add("lo", 10);
+        _instance.Variables.Add("hi", 11);
+        _instance.AddExpression<int>("e", "rand.Next(lo, hi)");
+        Assert.AreEqual(10, _instance.GetResult<int>("e"));
+    }
+
+    [TestMethod]
+    public void TwoArgInstanceMethod_StringSubstring_ReturnsExpected()
+    {
+        _instance.Variables.Add("s", "hello world");
+        _instance.AddExpression<string>("e", "s.Substring(6, 5)");
+        Assert.AreEqual("world", _instance.GetResult<string>("e"));
+    }
+
+    [TestMethod]
+    public void TwoArgStaticMethod_Imported_ReturnsMinimum()
+    {
+        _instance.Imports.AddType(typeof(Math));
+        _instance.Variables.Add("a", 3);
+        _instance.Variables.Add("b", 7);
+        _instance.AddExpression<int>("e", "Min(a, b)");
+        Assert.AreEqual(3, _instance.GetResult<int>("e"));
+    }
+
+    [TestMethod]
+    public void TwoArgStaticMethod_Imported_ReturnsMaximum()
+    {
+        _instance.Imports.AddType(typeof(Math));
+        _instance.Variables.Add("a", 3);
+        _instance.Variables.Add("b", 7);
+        _instance.AddExpression<int>("e", "Max(a, b)");
+        Assert.AreEqual(7, _instance.GetResult<int>("e"));
+    }
+
+    [TestMethod]
+    public void ThreeArgStaticMethod_Imported_ReturnsClampedValue()
+    {
+        _instance.Imports.AddType(typeof(Math));
+        _instance.AddExpression<double>("e", "Clamp(5.0, 1.0, 10.0)");
+        Assert.AreEqual(5.0, _instance.GetResult<double>("e"));
+    }
+
+    [TestMethod]
+    public void TwoArgInstanceMethod_ResultUsedInExpression_ReturnsExpected()
+    {
+        _instance.Variables.Add("rand", new Random());
+        _instance.AddExpression<int>("e", "rand.Next(3, 4) + rand.Next(7, 8)");
+        Assert.AreEqual(10, _instance.GetResult<int>("e"));
+    }
+}


### PR DESCRIPTION
## Summary

- The grammar fix in d06a583 (uncommenting `SUBPRODUCTION_16` in `ArgumentList`) already enables multi-argument function calls alongside the `in`-list form — no further parser changes needed.
- Adds `FunctionCall.cs` test class with 7 tests covering the newly-enabled code path: two-arg instance methods with literal and variable arguments, `String.Substring`, imported static `Math.Min/Max/Clamp`, and chained two-arg calls in a single expression.

## Test plan

- [ ] `TwoArgInstanceMethod_LiteralArgs_ReturnsExpected` — `rand.Next(5, 6)` → 5
- [ ] `TwoArgInstanceMethod_VariableArgs_ReturnsExpected` — `rand.Next(lo, hi)` with lo=10, hi=11 → 10
- [ ] `TwoArgInstanceMethod_StringSubstring_ReturnsExpected` — `s.Substring(6, 5)` → "world"
- [ ] `TwoArgStaticMethod_Imported_ReturnsMinimum` — `Min(a, b)` with a=3, b=7 → 3
- [ ] `TwoArgStaticMethod_Imported_ReturnsMaximum` — `Max(a, b)` with a=3, b=7 → 7
- [ ] `ThreeArgStaticMethod_Imported_ReturnsClampedValue` — `Clamp(5.0, 1.0, 10.0)` → 5.0
- [ ] `TwoArgInstanceMethod_ResultUsedInExpression_ReturnsExpected` — `rand.Next(3,4) + rand.Next(7,8)` → 10

https://claude.ai/code/session_01Hc2WjTPdTYEuNkZNMCZaQh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hc2WjTPdTYEuNkZNMCZaQh)_