### PR TITLE
Fix CaseSensitive=false not applying to variable name lookup

### DIFF
--- a/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
+++ b/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
@@ -125,4 +125,37 @@ public class ExpressionBuilderOptionsTests
         _instance.AddExpression("doubled", "RESULT * 2");
         Assert.AreEqual(16, _instance.GetResult<int>("doubled"));
     }
+
+    [TestMethod]
+    public void CaseSensitive_False_AllowsCaseInsensitiveVariableLookup()
+    {
+        _instance = new ComputeInstance(
+            new ComputeInstanceOptions
+            {
+                ExpressionOptions = new ExpressionBuilderOptions { CaseSensitive = false }
+            }
+        );
+        _instance.Variables.Add("myVar", 10);
+        _instance.AddExpression<int>("a", "myvar * 2");
+        Assert.AreEqual(20, _instance.GetResult<int>("a"));
+    }
+
+    [TestMethod]
+    public void CaseSensitive_False_VariableLookup_AutoRecalculate_UsesCanonicalKey()
+    {
+        var instance = new ComputeInstance(
+            new ComputeInstanceOptions
+            {
+                ExpressionOptions = new ExpressionBuilderOptions { CaseSensitive = false },
+                Recalculate = ComputeInstanceOptions.RecalculateMode.Auto,
+            }
+        );
+        instance.Variables.Add("myVar", 10);
+        instance.AddExpression<int>("a", "myvar * 2");
+        Assert.AreEqual(20, instance.GetResult<int>("a"));
+
+        // Updating via the canonical key must trigger recalculation
+        instance.Variables["myVar"] = 5;
+        Assert.AreEqual(10, instance.GetResult<int>("a"));
+    }
 }

--- a/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
+++ b/src/Yale.Tests/ExpressionTests/ExpressionBuilderOptionsTests.cs
@@ -158,4 +158,23 @@ public class ExpressionBuilderOptionsTests
         instance.Variables["myVar"] = 5;
         Assert.AreEqual(10, instance.GetResult<int>("a"));
     }
+
+    [TestMethod]
+    public void CaseSensitive_False_VariableLookup_AutoRecalculate_NonCanonicalUpdateKey()
+    {
+        var instance = new ComputeInstance(
+            new ComputeInstanceOptions
+            {
+                ExpressionOptions = new ExpressionBuilderOptions { CaseSensitive = false },
+                Recalculate = ComputeInstanceOptions.RecalculateMode.Auto,
+            }
+        );
+        instance.Variables.Add("myVar", 10);
+        instance.AddExpression<int>("a", "myvar * 2");
+        Assert.AreEqual(20, instance.GetResult<int>("a"));
+
+        // Updating via a different casing must also trigger recalculation
+        instance.Variables["MYVAR"] = 5;
+        Assert.AreEqual(10, instance.GetResult<int>("a"));
+    }
 }

--- a/src/Yale/Core/VariableCollection.cs
+++ b/src/Yale/Core/VariableCollection.cs
@@ -23,7 +23,17 @@ public sealed class VariableCollection
     private static readonly ConcurrentDictionary<Type, MethodInfo> GetVariableValueClosedMethods =
         new();
 
-    private readonly Dictionary<string, IVariable> values = new();
+    private readonly Dictionary<string, IVariable> values;
+
+    public VariableCollection()
+    {
+        values = new Dictionary<string, IVariable>();
+    }
+
+    internal VariableCollection(StringComparer comparer)
+    {
+        values = new Dictionary<string, IVariable>(comparer);
+    }
 
     public void Clear() => values.Clear();
 
@@ -99,6 +109,20 @@ public sealed class VariableCollection
 
     public ICollection<string> Keys => values.Keys;
     public ICollection<object> Values => values.Values.Select(v => v.ValueAsObject).ToList();
+
+    internal bool TryGetCanonicalKey(string key, [NotNullWhen(true)] out string? canonicalKey)
+    {
+        foreach (var k in values.Keys)
+        {
+            if (values.Comparer.Equals(k, key))
+            {
+                canonicalKey = k;
+                return true;
+            }
+        }
+        canonicalKey = null;
+        return false;
+    }
 
     /// <summary>
     /// This is used to crate a method call that can retrieve a value from the value collection

--- a/src/Yale/Core/VariableCollection.cs
+++ b/src/Yale/Core/VariableCollection.cs
@@ -94,16 +94,20 @@ public sealed class VariableCollection
 
             values[key] = new Variable(value);
 
+            // Use the canonical stored key so PropertyChanged fires consistently regardless
+            // of the casing the caller used, keeping dependency tracking correct.
+            var eventKey = TryGetCanonicalKey(key, out var canonical) ? canonical : key;
+
             //Todo: What is the point of this? The value has not been changed,
             //is has only been added to the variables collection
             if (value is INotifyPropertyChanged nValue)
             {
                 nValue.PropertyChanged += (sender, args) =>
                 {
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(key));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(eventKey));
                 };
             }
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(key));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(eventKey));
         }
     }
 

--- a/src/Yale/Engine/ComputeInstance.cs
+++ b/src/Yale/Engine/ComputeInstance.cs
@@ -294,6 +294,16 @@ public class ComputeInstance
 
     public bool ContainsExpression(string key) => nameNodeMap.ContainsKey(key);
 
+    internal string? GetCanonicalExpressionKey(string key)
+    {
+        foreach (var k in nameNodeMap.Keys)
+        {
+            if (nameNodeMap.Comparer.Equals(k, key))
+                return k;
+        }
+        return null;
+    }
+
     public int ExpressionCount => nameNodeMap.Count;
 
     public string DependencyGraph => dependencies.DependencyGraph;

--- a/src/Yale/Expression/Elements/MemberElements/IdentifierElement.cs
+++ b/src/Yale/Expression/Elements/MemberElements/IdentifierElement.cs
@@ -50,7 +50,9 @@ internal sealed class IdentifierElement : MemberElement
         // Expression lookup from compute instance
         if (computeInstance?.ContainsExpression(MemberName) == true)
         {
-            computeInstance.AddDependency(Context.ExpressionName, MemberName);
+            var expressionDependencyKey =
+                computeInstance.GetCanonicalExpressionKey(MemberName) ?? MemberName;
+            computeInstance.AddDependency(Context.ExpressionName, expressionDependencyKey);
             calcEngineReferenceType = computeInstance.ResultType(MemberName);
             return;
         }

--- a/src/Yale/Expression/Elements/MemberElements/IdentifierElement.cs
+++ b/src/Yale/Expression/Elements/MemberElements/IdentifierElement.cs
@@ -40,7 +40,10 @@ internal sealed class IdentifierElement : MemberElement
         if (Context.Variables.TryGetValue(MemberName, out IVariable? value))
         {
             valueType = value.Type;
-            computeInstance?.AddDependency(Context.ExpressionName, MemberName);
+            var dependencyKey = Context.Variables.TryGetCanonicalKey(MemberName, out var canonical)
+                ? canonical
+                : MemberName;
+            computeInstance?.AddDependency(Context.ExpressionName, dependencyKey);
             return;
         }
 

--- a/src/Yale/Expression/ExpressionBuilder.cs
+++ b/src/Yale/Expression/ExpressionBuilder.cs
@@ -18,7 +18,7 @@ internal sealed class ExpressionBuilder
 
     private const string DynamicMethodName = "DynamicMethod";
 
-    internal VariableCollection Variables { get; } = new VariableCollection();
+    internal VariableCollection Variables { get; }
 
     public ImportCollection Imports { get; }
 
@@ -26,6 +26,7 @@ internal sealed class ExpressionBuilder
     {
         Options = new ExpressionBuilderOptions();
         ComputeInstance = instance;
+        Variables = new VariableCollection(Options.StringComparer);
         Imports = new ImportCollection(Options);
         Analyzer = new YaleExpressionAnalyzer();
         Parser = new ExpressionParser(TextReader.Null, Analyzer);
@@ -35,6 +36,7 @@ internal sealed class ExpressionBuilder
     {
         Options = options;
         ComputeInstance = instance;
+        Variables = new VariableCollection(Options.StringComparer);
         Imports = new ImportCollection(Options);
         Analyzer = new YaleExpressionAnalyzer();
         Parser = new ExpressionParser(TextReader.Null, Analyzer);


### PR DESCRIPTION
## Summary

- `VariableCollection` was always constructed with a case-sensitive `Dictionary<string, IVariable>`, so variables added as `myVar` were never reachable as `myvar` even when `CaseSensitive = false`.
- `ExpressionBuilder` now passes `Options.StringComparer` when constructing `VariableCollection`, giving the dictionary `OrdinalIgnoreCase` semantics when `CaseSensitive = false`.
- `IdentifierElement` now normalises the dependency key to the canonical key stored in the dictionary, so auto-recalculation fires correctly when the variable is updated via its original casing rather than the casing used in the expression.

## Test plan

- [ ] `CaseSensitive_False_AllowsCaseInsensitiveVariableLookup` — variable added as `myVar`, referenced as `myvar` in expression, result is correct
- [ ] `CaseSensitive_False_VariableLookup_AutoRecalculate_UsesCanonicalKey` — same scenario with `RecalculateMode.Auto`; updating `Variables["myVar"]` triggers recalculation
- [ ] All existing tests (default case-sensitive behaviour, member access, expression reference) continue to pass

https://claude.ai/code/session_01ETPKuHqfS76kXVi4dTrZd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETPKuHqfS76kXVi4dTrZd4)_