### PR TITLE
refactor: tighten type safety in expression pipeline

### DIFF
--- a/src/Yale/Core/VariableCollection.cs
+++ b/src/Yale/Core/VariableCollection.cs
@@ -67,7 +67,7 @@ public sealed class VariableCollection
 
     public bool Remove(string key) => values.Remove(key);
 
-    public bool TryGetValue(string key, out object? value)
+    public bool TryGetValue(string key, [NotNullWhen(true)] out object? value)
     {
         var success = values.TryGetValue(key, out var result);
         value = result?.ValueAsObject;

--- a/src/Yale/Engine/ComputeInstance.cs
+++ b/src/Yale/Engine/ComputeInstance.cs
@@ -125,7 +125,7 @@ public class ComputeInstance
         node.Recalculate();
 
         //No need to recalculate dependents if value is the same.
-        if (result.Equals(node.ResultAsObject))
+        if (Equals(result, node.ResultAsObject))
             return;
 
         using var dependents = dependencies.GetDependents(key);
@@ -210,11 +210,11 @@ public class ComputeInstance
     }
 
     /// <summary>
-    /// Get expression result
+    /// Get expression result. May be null when the expression evaluates to null.
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    public object GetResult(string key)
+    public object? GetResult(string key)
     {
         ArgumentNullException.ThrowIfNull(key);
 
@@ -226,7 +226,7 @@ public class ComputeInstance
     }
 
     /// <summary>
-    /// Get expression result
+    /// Get expression result. Cast to T; T should accommodate null when the expression can evaluate to null.
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
@@ -234,14 +234,14 @@ public class ComputeInstance
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        return (T)GetResult(key);
+        return (T)GetResult(key)!;
     }
 
     public bool TryGetResult(string key, [NotNullWhen(true)] out object? result)
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        result = nameNodeMap.ContainsKey(key) ? GetResult(key) : default;
+        result = nameNodeMap.ContainsKey(key) ? GetResult(key) : null;
         return result != null;
     }
 
@@ -250,7 +250,7 @@ public class ComputeInstance
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        result = nameNodeMap.ContainsKey(key) ? (T)GetResult(key) : default;
+        result = nameNodeMap.ContainsKey(key) ? (T?)GetResult(key) : null;
         return result != null;
     }
 

--- a/src/Yale/Engine/Interface/IExpressionResult.cs
+++ b/src/Yale/Engine/Interface/IExpressionResult.cs
@@ -4,7 +4,7 @@ internal interface IExpressionResult
 {
     string Name { get; }
 
-    object ResultAsObject { get; }
+    object? ResultAsObject { get; }
 
     Type? ResultType { get; }
 

--- a/src/Yale/Engine/Internal/ExpressionResult.cs
+++ b/src/Yale/Engine/Internal/ExpressionResult.cs
@@ -30,13 +30,9 @@ internal sealed class ExpressionResult<T> : IExpressionResult
 
     public bool Dirty { get; set; }
 
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-    public Type ResultType => Result.GetType();
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
+    public Type? ResultType => Result?.GetType();
 
-#pragma warning disable CS8603 // Possible null reference return.
-    public object ResultAsObject => Result;
-#pragma warning restore CS8603 // Possible null reference return.
+    public object? ResultAsObject => Result;
 
     public Expression<T> GetExpression() => Expression;
 

--- a/src/Yale/Expression/Elements/Base/MemberElement.cs
+++ b/src/Yale/Expression/Elements/Base/MemberElement.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Yale.Core;
+﻿using Yale.Core;
 using Yale.Parser.Internal;
 using Yale.Resources;
 
@@ -197,31 +196,14 @@ internal abstract class MemberElement : BaseExpressionElement
     /// </summary>
     /// <param name="member"></param>
     /// <returns></returns>
-    private static bool IsMemberPublic(MemberInfo member)
-    {
-        var fieldInfo = member as FieldInfo;
-        if (fieldInfo is not null)
+    private static bool IsMemberPublic(MemberInfo member) =>
+        member switch
         {
-            return fieldInfo.IsPublic;
-        }
-
-        var propertyInfo = member as PropertyInfo;
-        if (propertyInfo is not null)
-        {
-            var method = propertyInfo.GetGetMethod(true);
-            return method?.IsPublic ?? false;
-        }
-
-        var methodInfo = member as MethodInfo;
-        if (methodInfo is not null)
-        {
-            return methodInfo.IsPublic;
-        }
-
-        //Todo: handle error case properly
-        Debug.Assert(false, "Unknown member type");
-        return false;
-    }
+            FieldInfo fieldInfo => fieldInfo.IsPublic,
+            PropertyInfo propertyInfo => propertyInfo.GetGetMethod(true)?.IsPublic ?? false,
+            MethodInfo methodInfo => methodInfo.IsPublic,
+            _ => false,
+        };
 
     protected static MemberInfo[] GetAccessibleMembers(MemberInfo[] members)
     {

--- a/src/Yale/Expression/Elements/InElement.cs
+++ b/src/Yale/Expression/Elements/InElement.cs
@@ -9,24 +9,20 @@ internal sealed class InElement : BaseExpressionElement
     // Element we will search for
     private readonly BaseExpressionElement operand;
 
-    // Elements we will compare against
-    private readonly List<BaseExpressionElement> arguments;
+    // Elements we will compare against (only set in list-search mode)
+    private readonly List<BaseExpressionElement>? arguments;
 
-    // Collection to look in
-    private readonly BaseExpressionElement targetCollectionElement;
+    // Collection to look in (only set in collection-search mode)
+    private readonly BaseExpressionElement? targetCollectionElement;
 
-    // Type of the collection
-    private Type targetCollectionType;
+    // Type of the collection (only set in collection-search mode)
+    private readonly Type? targetCollectionType;
 
     // Initialize for searching a list of values
-    public InElement(BaseExpressionElement operand, IList listElements)
+    public InElement(BaseExpressionElement operand, IEnumerable<BaseExpressionElement> listElements)
     {
         this.operand = operand;
-
-        BaseExpressionElement[] elements = new BaseExpressionElement[listElements.Count];
-        listElements.CopyTo(elements, 0);
-
-        arguments = new List<BaseExpressionElement>(elements);
+        arguments = listElements.ToList();
         ResolveForListSearch();
     }
 
@@ -35,7 +31,7 @@ internal sealed class InElement : BaseExpressionElement
     {
         this.operand = operand;
         targetCollectionElement = targetCollection;
-        ResolveForCollectionSearch();
+        targetCollectionType = ResolveForCollectionSearch();
     }
 
     private void ResolveForListSearch()
@@ -43,29 +39,29 @@ internal sealed class InElement : BaseExpressionElement
         CompareElement compareElement = new();
 
         // Validate that our operand is comparable to all elements in the list
-        foreach (var argumentElement in arguments)
+        foreach (var argumentElement in arguments!)
         {
             compareElement.Initialize(operand, argumentElement, LogicalCompareOperation.Equal);
             compareElement.Validate();
         }
     }
 
-    private void ResolveForCollectionSearch()
+    private Type ResolveForCollectionSearch()
     {
         // Try to find a collection type
-        targetCollectionType = GetTargetCollectionType();
+        var resolvedType = GetTargetCollectionType();
 
-        if (targetCollectionType is null)
+        if (resolvedType is null)
         {
             throw CreateCompileException(
                 CompileErrors.SearchArgIsNotKnownCollectionType,
                 CompileExceptionReason.TypeMismatch,
-                targetCollectionElement.ResultType.Name
+                targetCollectionElement!.ResultType.Name
             );
         }
 
         // Validate that the operand type is compatible with the collection
-        var methodInfo = GetCollectionContainsMethod();
+        var methodInfo = GetCollectionContainsMethod(resolvedType);
         var firstParameter = methodInfo.GetParameters()[0];
 
         if (
@@ -83,11 +79,13 @@ internal sealed class InElement : BaseExpressionElement
                 firstParameter.ParameterType.Name
             );
         }
+
+        return resolvedType;
     }
 
-    private Type GetTargetCollectionType()
+    private Type? GetTargetCollectionType()
     {
-        var collType = targetCollectionElement.ResultType;
+        var collType = targetCollectionElement!.ResultType;
 
         // Try to see if the collection is a generic ICollection or IDictionary
         var interfaces = collType.GetInterfaces();
@@ -153,11 +151,11 @@ internal sealed class InElement : BaseExpressionElement
     private void EmitCollectionIn(YaleIlGenerator ilg, ExpressionContext context)
     {
         // Get the contains method
-        var methodInfo = GetCollectionContainsMethod();
+        var methodInfo = GetCollectionContainsMethod(targetCollectionType!);
         var firstParameter = methodInfo.GetParameters()[0];
 
         // Load the collection
-        targetCollectionElement.Emit(ilg, context);
+        targetCollectionElement!.Emit(ilg, context);
         // Load the argument
         operand.Emit(ilg, context);
         // Do an implicit convert if necessary
@@ -170,14 +168,14 @@ internal sealed class InElement : BaseExpressionElement
         ilg.Emit(OpCodes.Callvirt, methodInfo);
     }
 
-    private MethodInfo GetCollectionContainsMethod()
+    private static MethodInfo GetCollectionContainsMethod(Type collectionType)
     {
         var methodName = "Contains";
 
         if (
-            targetCollectionType.IsGenericType
+            collectionType.IsGenericType
             && ReferenceEquals(
-                targetCollectionType.GetGenericTypeDefinition(),
+                collectionType.GetGenericTypeDefinition(),
                 typeof(IDictionary<,>)
             )
         )
@@ -185,10 +183,10 @@ internal sealed class InElement : BaseExpressionElement
             methodName = "ContainsKey";
         }
 
-        return targetCollectionType.GetMethod(
+        return collectionType.GetMethod(
             methodName,
             BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase
-        );
+        )!;
     }
 
     private void EmitListIn(
@@ -212,7 +210,7 @@ internal sealed class InElement : BaseExpressionElement
         LocalBasedElement targetShim = new(operand, targetIndex);
 
         // Emit the compares
-        foreach (var argumentElement in arguments)
+        foreach (var argumentElement in arguments!)
         {
             compareElement.Initialize(targetShim, argumentElement, LogicalCompareOperation.Equal);
             compareElement.Emit(ilg, context);

--- a/src/Yale/Expression/Elements/MemberElements/ArgumentList.cs
+++ b/src/Yale/Expression/Elements/MemberElements/ArgumentList.cs
@@ -10,11 +10,9 @@ internal sealed class ArgumentList
 {
     private readonly BaseExpressionElement[] _elements;
 
-    public ArgumentList(ICollection elements)
+    public ArgumentList(IEnumerable<BaseExpressionElement> elements)
     {
-        var arr = new BaseExpressionElement[elements.Count];
-        elements.CopyTo(arr, 0);
-        _elements = arr;
+        _elements = elements.ToArray();
     }
 
     private string[] GetArgumentTypeNames()

--- a/src/Yale/Parser/ParserLogException.cs
+++ b/src/Yale/Parser/ParserLogException.cs
@@ -9,7 +9,7 @@ public class ParserLogException : Exception
     /**
      * The list of errors found.
      */
-    private readonly ArrayList errors = new();
+    private readonly List<ParseException> errors = new();
 
     /**
      * Creates a new empty parser log exception.
@@ -60,7 +60,7 @@ public class ParserLogException : Exception
      */
     public ParseException this[int index]
     {
-        get { return (ParseException)errors[index]; }
+        get { return errors[index]; }
     }
 
     /**

--- a/src/Yale/Parser/YaleExpressionAnalyzer.cs
+++ b/src/Yale/Parser/YaleExpressionAnalyzer.cs
@@ -151,7 +151,7 @@ internal sealed class YaleExpressionAnalyzer : ExpressionAnalyzer
     public override Production ExitIndexExpression(Production production)
     {
         var childValues = GetChildValues(production);
-        ArgumentList args = new(childValues);
+        ArgumentList args = new(childValues.Cast<BaseExpressionElement>());
         IndexerElement e = new(args);
         production.Values.Add(e);
         return production;
@@ -202,7 +202,7 @@ internal sealed class YaleExpressionAnalyzer : ExpressionAnalyzer
 
         if (second is IList list)
         {
-            op = new(operand, list);
+            op = new(operand, list.Cast<BaseExpressionElement>());
         }
         else
         {
@@ -288,7 +288,7 @@ internal sealed class YaleExpressionAnalyzer : ExpressionAnalyzer
         var childValues = GetChildValues(production);
         var name = (string)childValues[0];
         childValues.RemoveAt(0);
-        ArgumentList args = new(childValues);
+        ArgumentList args = new(childValues.Cast<BaseExpressionElement>());
         FunctionCallElement funcCall = new(name, args);
         production.Values.Add(funcCall);
         return production;


### PR DESCRIPTION
## Summary

Replaces non-generic collections, surfaces nullability honestly, and clarifies intent across the expression compilation pipeline.

- `IExpressionResult.ResultAsObject` and `ExpressionResult<T>.ResultType` are nullable now that expression evaluation may legitimately yield `null`; drops the `CS8602`/`CS8603` pragmas in `ExpressionResult<T>`.
- `ComputeInstance.GetResult` mirrors the same with `object?`; `TryGetResult` fallback uses `null` directly.
- `ParserLogException` now stores `List<ParseException>` instead of `ArrayList`, removing the indexer cast.
- `ArgumentList` and `InElement` constructors take `IEnumerable<BaseExpressionElement>`; the heterogeneous `List<object>` produced by the analyzer is cast once at the boundary.
- `InElement` marks list-mode and collection-mode fields nullable; `GetTargetCollectionType` returns `Type?`; `GetCollectionContainsMethod` takes the type as a parameter so callers cannot read a null field.
- `MemberElement.IsMemberPublic` collapses to a switch expression and drops the now-unused `System.Diagnostics` import.
- `VariableCollection.TryGetValue` adds `[NotNullWhen(true)]` so flow analysis matches the runtime guard.

No behavioral changes intended; same nullability contract surfaced in the type system.

## Test plan

- [ ] `dotnet build` succeeds (sandbox lacks the .NET SDK; CI must validate)
- [ ] `dotnet test` passes — particularly `InTests`, `Boolean`, `Operator`, `Variable`, and `Cast` suites that exercise the touched code paths
- [ ] `dotnet csharpier --check .` reports no formatting drift

https://claude.ai/code/session_01AJroJNNy2oikFD53f4Li1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJroJNNy2oikFD53f4Li1N)_